### PR TITLE
changes to persist influx db storage and standardize resource names

### DIFF
--- a/jmeter/docker/jmetertestrig/templates/_helpers.tpl
+++ b/jmeter/docker/jmetertestrig/templates/_helpers.tpl
@@ -1,0 +1,10 @@
+{{/* vim: set filetype=mustache: */}}
+{{/* Expand the name of the chart. */}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{/* Create a default fully qualified app name. We truncate at 63 chars because . . . */}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/jmeter/docker/jmetertestrig/templates/jmeter_influxdb_deploy.yaml
+++ b/jmeter/docker/jmetertestrig/templates/jmeter_influxdb_deploy.yaml
@@ -20,50 +20,27 @@ items:
   metadata:
     creationTimestamp: null
     labels:
-      app: influxdb-jmeter
+      app: influxdb
     name: influxdb-config
-- apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    creationTimestamp: null
-    name: influx-storage
-  spec:
-    metadata:
-      annotations:
-        helm.sh/resource-policy: "keep"
-    accessModes:
-    - ReadWriteOnce
-    resources:
-      requests:
-        storage: 10Gi
-    storageClassName: default
-    volumeMode: Filesystem
-  status:
-    phase: Pending
 - apiVersion: apps/v1
-  kind: Deployment
+  kind: StatefulSet
   metadata:
     creationTimestamp: null
     labels:
-      app: influxdb-jmeter
-    name: influxdb-jmeter
+      app: influxdb
+    name: influxdb
   spec:
-    progressDeadlineSeconds: 600
     replicas: 1
     revisionHistoryLimit: 10
     selector:
       matchLabels:
-        app: influxdb-jmeter
-    strategy:
-      rollingUpdate:
-        maxSurge: 25%
-        maxUnavailable: 25%
-      type: RollingUpdate
+        app: influxdb
+    serviceName: {{ template "fullname" . }}-influxdb-svc
     template:
       metadata:
         creationTimestamp: null
         labels:
-          app: influxdb-jmeter
+          app: influxdb
       spec:
         containers:
         - image: {{ .Values.jmeterInfluxDbImage }}
@@ -92,7 +69,7 @@ items:
           - mountPath: /etc/influxdb
             name: config-volume
           - mountPath: /var/lib/influxdb
-            name: azureinflux
+            name: influx-data
         dnsPolicy: ClusterFirst
         restartPolicy: Always
         schedulerName: default-scheduler
@@ -103,17 +80,22 @@ items:
             defaultMode: 420
             name: influxdb-config
           name: config-volume
-        - name: azureinflux
-          persistentVolumeClaim:
-            claimName: influx-storage
-  status: {}
+    volumeClaimTemplates:
+      - metadata:
+          name: influx-data
+        spec:
+          accessModes: [ "ReadWriteOnce" ]
+          storageClassName: {{ .Values.jmeterInfluxDbStorageClass }}
+          resources:
+            requests:
+              storage: 10Gi
 - apiVersion: v1
   kind: Service
   metadata:
     creationTimestamp: null
     labels:
-      app: influxdb-jmeter
-    name: jmeter-influxdb-svc
+      app: influxdb
+    name: {{ template "fullname" . }}-influxdb-svc
   spec:
     ports:
     - name: http
@@ -129,7 +111,7 @@ items:
       protocol: TCP
       targetPort: 2003
     selector:
-      app: influxdb-jmeter
+      app: influxdb
     sessionAffinity: None
     type: ClusterIP
   status:

--- a/jmeter/docker/jmetertestrig/templates/jmeter_influxdb_deploy.yaml
+++ b/jmeter/docker/jmetertestrig/templates/jmeter_influxdb_deploy.yaml
@@ -21,14 +21,18 @@ items:
     creationTimestamp: null
     labels:
       app: influxdb
-    name: influxdb-config
+      chart: {{ template "name" . }}
+      release: {{ .Release.Name }}
+    name: {{ template "fullname" . }}-influxdb-config
 - apiVersion: apps/v1
   kind: StatefulSet
   metadata:
     creationTimestamp: null
     labels:
       app: influxdb
-    name: influxdb
+      chart: {{ template "name" . }}
+      release: {{ .Release.Name }}
+    name: {{ template "fullname" . }}-influxdb
   spec:
     replicas: 1
     revisionHistoryLimit: 10
@@ -41,6 +45,8 @@ items:
         creationTimestamp: null
         labels:
           app: influxdb
+          chart: {{ template "name" . }}
+          release: {{ .Release.Name }}
       spec:
         containers:
         - image: {{ .Values.jmeterInfluxDbImage }}
@@ -78,7 +84,7 @@ items:
         volumes:
         - configMap:
             defaultMode: 420
-            name: influxdb-config
+            name: {{ template "fullname" . }}-influxdb-config
           name: config-volume
     volumeClaimTemplates:
       - metadata:
@@ -95,6 +101,8 @@ items:
     creationTimestamp: null
     labels:
       app: influxdb
+      chart: {{ template "name" . }}
+      release: {{ .Release.Name }}
     name: {{ template "fullname" . }}-influxdb-svc
   spec:
     ports:

--- a/jmeter/docker/jmetertestrig/templates/jmeter_master_deploy.yaml
+++ b/jmeter/docker/jmetertestrig/templates/jmeter_master_deploy.yaml
@@ -8,16 +8,18 @@ items:
       #Script created to invoke jmeter test script with the slave POD IP addresses
       #Script should be run like: ./load_test "path to the test script in jmx format"
       #This is from the configmap
-      /jmeter/apache-jmeter-*/bin/jmeter -n -t $1 -Dserver.rmi.ssl.disable=true -R 'getent ahostsv4 jmeter-slaves-svc | cut -d' ' -f1 | sort -u | awk -v ORS=, '{print $1}' | sed 's/,$//''
+      /jmeter/apache-jmeter-*/bin/jmeter -n -t $1 -Dserver.rmi.ssl.disable=true -R 'getent ahostsv4 {{ template "fullname" . }}-jmeter-slaves-svc | cut -d' ' -f1 | sort -u | awk -v ORS=, '{print $1}' | sed 's/,$//''
   metadata:
-      name: jmeter-load-test-script
+      name: {{ template "fullname" . }}-jmeter-load-test-script
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
     creationTimestamp: null
     labels:
       jmeter_mode: master
-    name: jmeter-master
+      chart: {{ template "name" . }}
+      release: {{ .Release.Name }}
+    name: {{ template "fullname" . }}-jmeter-master
   spec:
     progressDeadlineSeconds: 600
     replicas: 1
@@ -32,6 +34,8 @@ items:
         creationTimestamp: null
         labels:
           jmeter_mode: master
+          chart: {{ template "name" . }}
+          release: {{ .Release.Name }}
       spec:
         containers:
         - args:
@@ -63,6 +67,6 @@ items:
         volumes:
           - name: load-test-run
             configMap:
-              name: jmeter-load-test-script
+              name: {{ template "fullname" . }}-jmeter-load-test-script
 kind: List
 metadata: {}

--- a/jmeter/docker/jmetertestrig/templates/jmeter_slaves_deploy.yaml
+++ b/jmeter/docker/jmetertestrig/templates/jmeter_slaves_deploy.yaml
@@ -6,7 +6,7 @@ items:
     creationTimestamp: null
     labels:
       jmeter_mode: slave
-    name: jmeter-slaves
+    name: {{ template "fullname" . }}-jmeter-slaves
   spec:
     progressDeadlineSeconds: 600
     replicas: {{ .Values.replicaCount }}
@@ -21,6 +21,8 @@ items:
         creationTimestamp: null
         labels:
           jmeter_mode: slave
+          chart: {{ template "name" . }}
+          release: {{ .Release.Name }}
       spec:
         containers:
         - args:
@@ -66,7 +68,9 @@ items:
     creationTimestamp: null
     labels:
       jmeter_mode: slave
-    name: jmeter-slaves-svc
+      chart: {{ template "name" . }}
+      release: {{ .Release.Name }}
+    name: {{ template "fullname" . }}-jmeter-slaves-svc
   spec:
     clusterIP: None
     ports:

--- a/jmeter/docker/jmetertestrig/values.yaml
+++ b/jmeter/docker/jmetertestrig/values.yaml
@@ -5,5 +5,8 @@ replicaCount: 1
 jmeterMasterImage: shadowpic/jmeter-master:latest
 jmeterSlaveImage: shadowpic/jmeter-slave:latest
 jmeterInfluxDbImage: influxdb:1.8
+jmeterInfluxDbStorageClass:  # Allow specifying alternate StorageClass
 redis:
   usePassword: false
+  cluster:
+    enabled: false


### PR DESCRIPTION
- Replaced the influxdb deployment with a statefulset and volumeclaimtemplate
- added helm default template helper (generic version of https://github.com/helm/charts/blob/master/stable/wordpress/templates/_helpers.tpl)
- added a value for storageclassname (very helpful in cases where no default storageclass is defined)
- standardized names using template helper