### PR TITLE
Added script to publish previous/local result .jtl files to storage account 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PublicTestProjects
+# PublicTestProjects 
 
 This is dedicated to sharing solutions that I come across working with customers world wide.  
 

--- a/jmeter/docker/PublishPreviousResults.ps1
+++ b/jmeter/docker/PublishPreviousResults.ps1
@@ -4,7 +4,7 @@ param(
     [Parameter(Mandatory=$true)]
     [string]
     $tenant,
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory=$true)]
     [string]
     $TestName="",
     [Parameter(Mandatory=$true)]
@@ -28,7 +28,7 @@ if (!($null -eq $PublishPreviousResultsToStorageAccount) && !($PublishPreviousRe
     $resultFile=Get-ChildItem -Path $PublishPreviousResultsToStorageAccount -force | Where-Object Extension -in ('.jtl')
     if ((Get-Content $resultFile).Length -le 1) 
     {
-        Write-Host ".jtl file is empty"
+        Write-Output ".jtl file is empty"
         throw "jtl file with test results is required"
     }
  

--- a/jmeter/docker/PublishPreviousResults.ps1
+++ b/jmeter/docker/PublishPreviousResults.ps1
@@ -1,0 +1,51 @@
+#Requires -Version 7
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]
+    $tenant,
+    [Parameter(Mandatory=$false)]
+    [string]
+    $TestName="",
+    [Parameter(Mandatory=$true)]
+    [string]
+    $PublishPreviousResultsToStorageAccount,
+    [Parameter(Mandatory=$true)]
+    [string]
+    $StorageAccount="",
+    [Parameter(Mandatory=$true)]
+    [string]
+    $Container=""
+)
+
+Import-Module ./commenutils.psm1 -force
+
+if (!($null -eq $PublishPreviousResultsToStorageAccount) && !($PublishPreviousResultsToStorageAccount -eq "")) 
+{
+    Write-Output "Publishing previous results to storage account"
+
+    IsJTLPresent -resultFile $PublishPreviousResultsToStorageAccount
+    $resultFile=Get-ChildItem -Path $PublishPreviousResultsToStorageAccount -force | Where-Object Extension -in ('.jtl')
+    if ((Get-Content $resultFile).Length -le 1) 
+    {
+        Write-Host ".jtl file is empty"
+        throw "jtl file with test results is required"
+    }
+ 
+    
+    $firstResultLine=Get-Content -Path $resultFile | Select-Object -index 1
+    $timestamp=$firstResultLine.Substring(0,$firstResultLine.IndexOf(','))
+    $destinationPath=ConvertUnixTimeToUTC -timestamp $timestamp
+
+    [xml]$testPlanXml=Get-Content $TestName
+    if(!($testPlanXml.SelectNodes("//TestPlan").testname -eq "Test Plan"))
+    {
+        $destinationPath = $testPlanXml.SelectNodes("//TestPlan").testname + "/" + $destinationPath
+    }  
+
+    Write-Output "Publishing to storage account $StorageAccount to folder $destinationPath"
+    Write-Output "Adding the AZ storage-preview extension"
+    az extension add --name storage-preview
+    Write-Output "Attempting to upload to storage account using the current AZ Security context"
+    PublishResultsToStorageAccount -container $Container -StorageAccountName $StorageAccount -DestinationPath $destinationPath -SourceDirectory $PublishPreviousResultsToStorageAccount
+}

--- a/jmeter/docker/commenutils.psm1
+++ b/jmeter/docker/commenutils.psm1
@@ -1,8 +1,8 @@
 #Requires -Version 7
 function VerifyKubeCtl
 {
-    if ($null -eq (Get-Command "kubectl.exe" -ErrorAction SilentlyContinue)) 
-    { 
+    if ($null -eq (Get-Command "kubectl.exe" -ErrorAction SilentlyContinue))
+    {
         Write-Host "Unable to find kubectl.exe in your PATH"
         throw "kubectl is required"
     }
@@ -22,10 +22,10 @@ function VerifyHelm3
 
 function IsJmeterHelmDeployed($tenant)
 {
-    
+
     [string]$deploymentStatus=Helm status jmeter --namespace jmeter
     [boolean]$match = $deploymentStatus -like "*STATUS: deployed*"
-    return $match 
+    return $match
 }
 
 function GetRedisMaster ($tenant)
@@ -47,4 +47,19 @@ function PublishResultsToStorageAccount($container,$StorageAccountName,$Destinat
 {
     az extension add --name storage-preview
     az storage azcopy blob upload --container $container --account-name $StorageAccountName --destination $DestinationPath --source $SourceDirectory --recursive
+}
+
+function PublishPreviousResultsToStorageAccount($container,$StorageAccountName,$DestinationPath,$SourceDirectory)
+{
+    az extension add --name storage-preview
+    [bool]$jtlPresent = (Get-ChildItem -Path $SourceDirectory -force | Where-Object Extension -in ('.jtl') | Measure-Object).Count -ne 0
+    if ($jtlPresent)
+    {
+        az storage azcopy blob upload --container $container --account-name $StorageAccountName --destination $DestinationPath --source $SourceDirectory --recursive
+    }
+    else
+    {
+        Write-Host ".jtl file not present"
+        throw ".jtl file is required"
+    }
 }

--- a/jmeter/docker/commenutils.psm1
+++ b/jmeter/docker/commenutils.psm1
@@ -49,12 +49,14 @@ function PublishResultsToStorageAccount($container,$StorageAccountName,$Destinat
     az storage azcopy blob upload --container $container --account-name $StorageAccountName --destination $DestinationPath --source $SourceDirectory --recursive
 }
 
-function IsResultInStoragAccount($container,$StorageAccountName,$blob)
+function IsResultInStoragAccount($container,$StorageAccountName,$blob,$accountKey)
 {
-    $accountKey=az storage account keys list --account-name $StorageAccountName --query [0].value
-    #return $accountKey
-    #$sasToken=az storage blob generate-sas --account-name $StorageAccountName --container-name $container
     return az storage blob exists --account-key $accountKey --account-name $StorageAccountName --container-name $container --name $blob --query exists
+}
+
+function RetrieveStorageAccountKey($storageAccountName) 
+{
+    return az storage account keys list --account-name $StorageAccountName --query [0].value
 }
 
 function ConvertUnixTimeToUTC($timestamp)
@@ -80,5 +82,25 @@ function IsJTLPresent($resultFile)
     {
         Write-Host ".jtl file not present"
         throw ".jtl file is required"
+    }
+}
+
+function CreateReportDirectory($reportFolderName,$isTestInReport,$testName,$resultFile,$currentWorkingDirectory)
+{
+    New-Item -Path $currentWorkingDirectory -Name $ReportFolderName -ItemType "directory"
+    Copy-Item -Path $resultFile -Destination $currentWorkingDirectory"/"$ReportFolderName"/results.jtl" -Force
+    Copy-Item -Path $resultFile -Destination $currentWorkingDirectory"/"$ReportFolderName -Force
+
+    if ($isTestInReport)
+    {
+        Copy-Item -Path $testName -Destination $currentWorkingDirectory"/"$ReportFolderName -Force
+    }
+}
+
+function DoesReportDirectoryExist($reportFolderName)
+{
+    if (Test-Path -Path $reportFolderName)
+    {
+        Remove-Item -LiteralPath $reportFolderName -Force -Recurse
     }
 }

--- a/jmeter/docker/commenutils.psm1
+++ b/jmeter/docker/commenutils.psm1
@@ -49,16 +49,19 @@ function PublishResultsToStorageAccount($container,$StorageAccountName,$Destinat
     az storage azcopy blob upload --container $container --account-name $StorageAccountName --destination $DestinationPath --source $SourceDirectory --recursive
 }
 
-function PublishPreviousResultsToStorageAccount($container,$StorageAccountName,$DestinationPath,$SourceDirectory)
+function ConvertUnixTimeToUTC($timestamp)
 {
-    az extension add --name storage-preview
+    $origin=New-Object -Type DateTime -ArgumentList 1970, 1, 1, 0, 0, 0, 0
+    $timestamp=$origin.AddSeconds([double]$timestamp/1000)
+    return Get-Date -Date $timestamp -format "yyyy/MM/dd" -AsUTC
+    
+}
 
-    [bool]$jtlPresent = (Get-ChildItem -Path $SourceDirectory -force | Where-Object Extension -in ('.jtl') | Measure-Object).Count -ne 0
-    if ($jtlPresent)
-    {
-        az storage azcopy blob upload --container $container --account-name $StorageAccountName --destination $DestinationPath --source $SourceDirectory --recursive
-    }
-    else
+function IsJTLPresent($resultFile)
+{
+    [bool]$jtlPresent = (Get-ChildItem -Path $resultFile -force | Where-Object Extension -in ('.jtl') | Measure-Object).Count -ne 0
+
+    if (!($jtlPresent))
     {
         Write-Host ".jtl file not present"
         throw ".jtl file is required"

--- a/jmeter/docker/commenutils.psm1
+++ b/jmeter/docker/commenutils.psm1
@@ -57,6 +57,13 @@ function ConvertUnixTimeToUTC($timestamp)
     
 }
 
+function ConvertUnixTimeToFileDateTimeUniversal($timestamp)
+{
+    $origin=New-Object -Type DateTime -ArgumentList 1970, 1, 1, 0, 0, 0, 0
+    $timestamp=$origin.AddSeconds([double]$timestamp/1000)
+    return Get-Date -Date $timestamp -format FileDateTimeUniversal -AsUTC
+}
+
 function IsJTLPresent($resultFile)
 {
     [bool]$jtlPresent = (Get-ChildItem -Path $resultFile -force | Where-Object Extension -in ('.jtl') | Measure-Object).Count -ne 0

--- a/jmeter/docker/commenutils.psm1
+++ b/jmeter/docker/commenutils.psm1
@@ -49,6 +49,14 @@ function PublishResultsToStorageAccount($container,$StorageAccountName,$Destinat
     az storage azcopy blob upload --container $container --account-name $StorageAccountName --destination $DestinationPath --source $SourceDirectory --recursive
 }
 
+function IsResultInStoragAccount($container,$StorageAccountName,$blob)
+{
+    $accountKey=az storage account keys list --account-name $StorageAccountName --query [0].value
+    #return $accountKey
+    #$sasToken=az storage blob generate-sas --account-name $StorageAccountName --container-name $container
+    return az storage blob exists --account-key $accountKey --account-name $StorageAccountName --container-name $container --name $blob --query exists
+}
+
 function ConvertUnixTimeToUTC($timestamp)
 {
     $origin=New-Object -Type DateTime -ArgumentList 1970, 1, 1, 0, 0, 0, 0

--- a/jmeter/docker/commenutils.psm1
+++ b/jmeter/docker/commenutils.psm1
@@ -52,6 +52,7 @@ function PublishResultsToStorageAccount($container,$StorageAccountName,$Destinat
 function PublishPreviousResultsToStorageAccount($container,$StorageAccountName,$DestinationPath,$SourceDirectory)
 {
     az extension add --name storage-preview
+
     [bool]$jtlPresent = (Get-ChildItem -Path $SourceDirectory -force | Where-Object Extension -in ('.jtl') | Measure-Object).Count -ne 0
     if ($jtlPresent)
     {

--- a/jmeter/docker/run_test.ps1
+++ b/jmeter/docker/run_test.ps1
@@ -183,7 +183,15 @@ if (!($PublishPreviousResultsToStorageAccount -eq $null))
 {
     Write-Output "Publishing previous results to storage account"
 
-    $destinationPath=get-date -format "yyyy/MM/dd" -AsUTC
+    # Retrieving date from file path
+    $destinationPathString=(Split-Path $PublishPreviousResultsToStorageAccount -Leaf).Substring(0,8)
+    $year=$destinationPathString.Substring(0,4)
+    $month=($destinationPathString.Substring(4)).Substring(0,2)
+    $day=$destinationPathString.Substring(6)
+    $stringDate=$year+"/"+$month+"/"+$day
+    $destinationPath=[datetime]::ParseExact($stringDate, "yyyy/MM/dd",$null)
+    $destinationPath=Get-Date -Date $destinationPath -format "yyyy/MM/dd" -AsUTC
+
     [xml]$testPlanXml=Get-Content $TestName
     if(!($testPlanXml.SelectNodes("//TestPlan").testname -eq "Test Plan"))
     {

--- a/jmeter/docker/run_test.ps1
+++ b/jmeter/docker/run_test.ps1
@@ -91,6 +91,9 @@ param(
     $PublishResultsToBlobStorage,
     [Parameter(Mandatory=$false)]
     [string]
+    $PublishPreviousResultsToStorageAccount,
+    [Parameter(Mandatory=$false)]
+    [string]
     $StorageAccount="",
     [Parameter(Mandatory=$false)]
     [string]
@@ -172,6 +175,24 @@ if($PublishResultsToBlobStorage.IsPresent)
     Write-Output "Attempting to upload to storage account using the current AZ Security context"
     PublishResultsToStorageAccount -container $Container -StorageAccountName $StorageAccount -DestinationPath $destinationPath -SourceDirectory $ReportFolder
 }
+
+if (!($PublishPreviousResultsToStorageAccount -eq $null)) 
+{
+    Write-Output "Publishing previous results to storage account"
+
+    $destinationPath=get-date -format "yyyy/MM/dd" -AsUTC
+    [xml]$testPlanXml=Get-Content $TestName
+    if(!($testPlanXml.SelectNodes("//TestPlan").testname -eq "Test Plan"))
+    {
+        $destinationPath = $testPlanXml.SelectNodes("//TestPlan").testname + "/" + $destinationPath
+    }
+    Write-Output "Publishing to storage account $StorageAccount to folder $destinationPath"
+    Write-Output "Adding the AZ storage-preview extension"
+    az extension add --name storage-preview
+    Write-Output "Attempting to upload to storage account using the current AZ Security context"
+    PublishPreviousResultsToStorageAccount -container $Container -StorageAccountName $StorageAccount -DestinationPath $destinationPath -SourceDirectory $PublishPreviousResultsToStorageAccount
+}
+
 if($DeleteTestRig)
 {
     $result = .\Set-JmeterTestRig.ps1 -tenant $tenant -ZeroOutTestRig $true

--- a/jmeter/docker/run_test.ps1
+++ b/jmeter/docker/run_test.ps1
@@ -36,6 +36,9 @@
 
     .PARAMETER PublishResultsToBlobStorage
     To enable the ability to do more advanced reporting like with PowerBi you can add this parameter to upload the contents of the results directory to an Azure Blob Storage.
+    
+    .PARAMETER $PublishPreviousResultsToStorageAccount
+    To enable the ability to upload contents of previous result files to Azure Blob Storage manually and view results in Power BI. 
 
     .PARAMETER StorageAccount
     The string name for the storage account you are uploading the results folder to

--- a/jmeter/docker/run_test.ps1
+++ b/jmeter/docker/run_test.ps1
@@ -65,6 +65,7 @@
 
 #Requires -Version 7
 
+#TODO: add parameter to see if user wants to upload jmx
 param(
     [Parameter(Mandatory=$true)]
     [string]

--- a/jmeter/docker/run_test.ps1
+++ b/jmeter/docker/run_test.ps1
@@ -179,31 +179,6 @@ if($PublishResultsToBlobStorage.IsPresent)
     PublishResultsToStorageAccount -container $Container -StorageAccountName $StorageAccount -DestinationPath $destinationPath -SourceDirectory $ReportFolder
 }
 
-if (!($PublishPreviousResultsToStorageAccount -eq $null)) 
-{
-    Write-Output "Publishing previous results to storage account"
-
-    # Retrieving date from file path
-    $destinationPathString=(Split-Path $PublishPreviousResultsToStorageAccount -Leaf).Substring(0,8)
-    $year=$destinationPathString.Substring(0,4)
-    $month=($destinationPathString.Substring(4)).Substring(0,2)
-    $day=$destinationPathString.Substring(6)
-    $stringDate=$year+"/"+$month+"/"+$day
-    $destinationPath=[datetime]::ParseExact($stringDate, "yyyy/MM/dd",$null)
-    $destinationPath=Get-Date -Date $destinationPath -format "yyyy/MM/dd" -AsUTC
-
-    [xml]$testPlanXml=Get-Content $TestName
-    if(!($testPlanXml.SelectNodes("//TestPlan").testname -eq "Test Plan"))
-    {
-        $destinationPath = $testPlanXml.SelectNodes("//TestPlan").testname + "/" + $destinationPath
-    }
-    Write-Output "Publishing to storage account $StorageAccount to folder $destinationPath"
-    Write-Output "Adding the AZ storage-preview extension"
-    az extension add --name storage-preview
-    Write-Output "Attempting to upload to storage account using the current AZ Security context"
-    PublishPreviousResultsToStorageAccount -container $Container -StorageAccountName $StorageAccount -DestinationPath $destinationPath -SourceDirectory $PublishPreviousResultsToStorageAccount
-}
-
 if($DeleteTestRig)
 {
     $result = .\Set-JmeterTestRig.ps1 -tenant $tenant -ZeroOutTestRig $true

--- a/jmeter/docker/run_test.ps1
+++ b/jmeter/docker/run_test.ps1
@@ -37,8 +37,8 @@
     .PARAMETER PublishResultsToBlobStorage
     To enable the ability to do more advanced reporting like with PowerBi you can add this parameter to upload the contents of the results directory to an Azure Blob Storage.
     
-    .PARAMETER $PublishPreviousResultsToStorageAccount
-    To enable the ability to upload contents of previous result files to Azure Blob Storage manually and view results in Power BI. 
+    .PARAMETER $PublishTestToStorageAccount
+    This feature includes the test file in the storage account and report folder
 
     .PARAMETER StorageAccount
     The string name for the storage account you are uploading the results folder to
@@ -65,7 +65,6 @@
 
 #Requires -Version 7
 
-#TODO: add parameter to see if user wants to upload jmx
 param(
     [Parameter(Mandatory=$true)]
     [string]
@@ -93,6 +92,9 @@ param(
     [Parameter(Mandatory=$false)]
     [Switch]
     $PublishResultsToBlobStorage,
+    [Parameter(Mandatory=$false)]
+    [switch]
+    $PublishTestToStorageAccount,
     [Parameter(Mandatory=$false)]
     [string]
     $PublishPreviousResultsToStorageAccount,
@@ -166,6 +168,11 @@ kubectl cp $tenant/${MasterPod}:/jmeter/apache-jmeter-5.3/bin/jmeter.log $Report
 
 if($PublishResultsToBlobStorage.IsPresent)
 {
+    if ($PublishTestToStorageAccount.IsPresent) 
+    {
+        Copy-Item -Path $TestName -Destination $ReportFolder -Force
+    } 
+
     $destinationPath=get-date -format "yyyy/MM/dd" -AsUTC
     #TODO: Add checking to ensure the minimum verson of AZ is installed already
     [xml]$testPlanXml=Get-Content $TestName


### PR DESCRIPTION
Allows user to publish previous result files to Azure Storage Account.

Looked into a few different ways of efficiently reading the first result line of the file without loading the entire file into memory:
 -- `[IO.File]::ReadLines($resultFile, [text.encoding]::UTF8) | Select-Object -Skip 1 -First 1`
 -- `New-Object System.IO.StreamReader($resultFile)`
 --` Get-Content -Path $resultFile | Select-Object -index 1`
Top 2 options were usually pretty close in time (~.20ms difference) with the second option being a little faster. 

Modified `run_test.ps1` to allow the user the option to include the test in the the Report Folder and Azure Storage Account