### PR TITLE
Fixes issue #53 of not allowing Drive letter of TestName when Copying to AKS

### DIFF
--- a/jmeter/docker/run_test.ps1
+++ b/jmeter/docker/run_test.ps1
@@ -152,7 +152,7 @@ foreach($gr in $GlobalJmeterParams)
 
 }
 Write-Output "Copying test plan to aks"
-kubectl cp $TestName $tenant/${MasterPod}:"/$(Split-Path $TestName -Leaf)"
+kubectl cp $(Split-Path $TestName -NoQualifier) $tenant/${MasterPod}:"/$(Split-Path $TestName -Leaf)"
 if($ExecuteOnceOnMaster.IsPresent)
 {
     Write-Output "Starting optional execution of jmx on the master node"


### PR DESCRIPTION
Fixes Issue  #53 by removing Drive letter of TestName when copying test plan to aks 