### PR TITLE
Added parameter so user can specify test report name and checking for empty result files

### DIFF
--- a/jmeter/docker/PublishPreviousResults.ps1
+++ b/jmeter/docker/PublishPreviousResults.ps1
@@ -60,7 +60,7 @@ param(
     $Container="",
     [Parameter(Mandatory=$false)]
     [string]
-    $StorageAccountPathTopLevel="Test Plan"
+    $StorageAccountPathTopLevel=""
 )
 
 Import-Module ./commenutils.psm1 -force
@@ -100,9 +100,15 @@ if (!($null -eq $PublishPreviousResultsToStorageAccount) && !($PublishPreviousRe
         $destinationPath=ConvertUnixTimeToUTC -timestamp $timestamp
 
         # Retrieving test plan name from parameter or using default Test Plan name
-        if (!($null -eq $StorageAccountPathTopLevel))
+        [xml]$testPlanXml=Get-Content $TestName
+         $testPlanName=$testPlanXml.SelectNodes("//TestPlan").testname
+        if (!($null -eq $StorageAccountPathTopLevel) -and !($StorageAccountPathTopLevel -eq "")) 
         {
             $destinationPath = $StorageAccountPathTopLevel + "/" + $destinationPath
+        }
+        elseif (!($testPlanName -eq "Test Plan") -and !($testPlanName -eq "") -and !($null -eq $testPlanName)) 
+        {
+            $destinationPath = $testPlanName + "/" + $destinationPath
         }
         else 
         {

--- a/jmeter/docker/commenutils.psm1
+++ b/jmeter/docker/commenutils.psm1
@@ -104,3 +104,25 @@ function DoesReportDirectoryExist($reportFolderName)
         Remove-Item -LiteralPath $reportFolderName -Force -Recurse
     }
 }
+
+function PromptUserForTestName($destinationPath,$testPlanXml,$file) 
+{
+    [bool]$askAgain=$true
+    while($askAgain)
+    {
+        if ([string]::IsNullOrEmpty($file))
+        {
+            $file="results.jtl"
+        }
+        $userInput=Read-Host -Prompt "The report is called $("Test Plan") for result file $($file). Do you want to change it? [Y or N]"
+        switch ($userInput) {
+            { @("n", "no") -contains $_ } { return "Test Plan/" + $destinationPath }
+            { @("y", "yes") -contains $_ } 
+            { 
+               $testPlanName=Read-Host -Prompt "Enter Test Plan Name"
+               return $testPlanName + "/" + $destinationPath 
+            }
+            default {'Input not recognized.'}
+        }
+    }
+}

--- a/jmeter/docker/run_test.ps1
+++ b/jmeter/docker/run_test.ps1
@@ -109,7 +109,7 @@ param(
     $Container="",
     [Parameter(Mandatory=$false)]
     [string]
-    $StorageAccountPathTopLevel="Test Plan",
+    $StorageAccountPathTopLevel="",
     [parameter(ValueFromRemainingArguments=$true)]
     [string[]]
     $GlobalJmeterParams
@@ -201,9 +201,15 @@ if($PublishResultsToBlobStorage.IsPresent)
 
     $destinationPath=get-date -format "yyyy/MM/dd" -AsUTC
     #TODO: Add checking to ensure the minimum verson of AZ is installed already
-    if (!($null -eq $StorageAccountPathTopLevel))
+    [xml]$testPlanXml=Get-Content $TestName
+    $testPlanName=$testPlanXml.SelectNodes("//TestPlan").testname
+    if (!($null -eq $StorageAccountPathTopLevel) -and !($StorageAccountPathTopLevel -eq "")) 
     {
         $destinationPath = $StorageAccountPathTopLevel + "/" + $destinationPath
+    }
+    elseif (!($testPlanName -eq "Test Plan") -and !($testPlanName -eq "") -and !($null -eq $testPlanName)) 
+    {
+        $destinationPath = $testPlanName + "/" + $destinationPath
     }
     else 
     {


### PR DESCRIPTION
- Added parameter to both run_test.ps1 and PublishPreviousResults.ps1 so that user can include unique test report name
- Both scripts check if result files are empty before publishing to storage account (Closing Issue #56)